### PR TITLE
Make network-ee test for utils non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -235,6 +235,8 @@
         - ansible-test-units-ansible-utils-python27
         - ansible-test-units-ansible-utils-python36
         - ansible-test-units-ansible-utils-python37
+        - network-ee-unit-tests:
+            voting: false
     gate:
       queue: integrated
       jobs: *ansible-collections-ansible-utils-units-jobs

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -212,7 +212,8 @@
     check:
       jobs: &ansible-collections-ansible-utils-jobs
         - build-ansible-collection
-        - network-ee-integration-tests-ansible-utils
+        - network-ee-integration-tests-ansible-utils:
+            voting: false
         - network-ee-integration-tests-ansible-utils-stable-2.12
         - network-ee-integration-tests-ansible-utils-stable-2.11
         - network-ee-integration-tests-ansible-utils-stable-2.9


### PR DESCRIPTION
Make network-ee test for utils non-voting until core fix get out for jinja2 failures

There are some failures in network-ee tests due to some changes in ansible devel branch.
we are making network-ee tests as non-voting as core team will release fix for these failures in next week.